### PR TITLE
Add ConfigureAwait to async calls

### DIFF
--- a/src/Nominatim.API/Address/AddressSearcher.cs
+++ b/src/Nominatim.API/Address/AddressSearcher.cs
@@ -30,7 +30,7 @@ namespace Nominatim.API.Address {
         /// <param name="req">Search request object</param>
         /// <returns>Array of lookup reponses</returns>
         public async Task<AddressLookupResponse[]> Lookup(AddressSearchRequest req) {
-            var result = await WebInterface.GetRequest<AddressLookupResponse[]>(url, buildQueryString(req));
+            var result = await WebInterface.GetRequest<AddressLookupResponse[]>(url, buildQueryString(req)).ConfigureAwait(false);
             return result;
         }
 

--- a/src/Nominatim.API/Geocoders/ForwardGeocoder.cs
+++ b/src/Nominatim.API/Geocoders/ForwardGeocoder.cs
@@ -22,7 +22,7 @@ namespace Nominatim.API.Geocoders {
         /// <param name="req">Geocode request object</param>
         /// <returns>Array of geocode responses</returns>
         public async Task<GeocodeResponse[]> Geocode(ForwardGeocodeRequest req) {
-            var result = await WebInterface.GetRequest<GeocodeResponse[]>(url, buildQueryString(req));
+            var result = await WebInterface.GetRequest<GeocodeResponse[]>(url, buildQueryString(req)).ConfigureAwait(false);
             return result;
         }
 

--- a/src/Nominatim.API/Geocoders/ReverseGeocoder.cs
+++ b/src/Nominatim.API/Geocoders/ReverseGeocoder.cs
@@ -22,7 +22,7 @@ namespace Nominatim.API.Geocoders {
         /// <param name="req">Reverse geocode request object</param>
         /// <returns>A single reverse geocode response</returns>
         public async Task<GeocodeResponse> ReverseGeocode(ReverseGeocodeRequest req) {
-            var result = await WebInterface.GetRequest<GeocodeResponse>(url, buildQueryString(req));
+            var result = await WebInterface.GetRequest<GeocodeResponse>(url, buildQueryString(req)).ConfigureAwait(false);
             return result;
         }
 

--- a/src/Nominatim.API/Web/WebInterface.cs
+++ b/src/Nominatim.API/Web/WebInterface.cs
@@ -22,7 +22,7 @@ namespace Nominatim.API.Web {
         public static async Task<T> GetRequest<T>(string url, Dictionary<string, string> parameters) {
             var req = QueryHelpers.AddQueryString(url, parameters);
 
-            var result = await _httpClient.GetStringAsync(req);
+            var result = await _httpClient.GetStringAsync(req).ConfigureAwait(false);
             var settings = new JsonSerializerSettings {ContractResolver = new PrivateContractResolver()};
 
             return JsonConvert.DeserializeObject<T>(result, settings);


### PR DESCRIPTION
This is done to prevent unwanted synchronisation when the calling thread has a SynchronisationContext.