### PR TITLE
osm_id is long

### DIFF
--- a/src/Nominatim.API/Models/BaseNominatimResponse.cs
+++ b/src/Nominatim.API/Models/BaseNominatimResponse.cs
@@ -25,7 +25,7 @@ namespace Nominatim.API.Models {
         /// The OSM ID of this element type.
         /// </summary>
         [JsonProperty("osm_id")]
-        public int OSMID { get; set; }
+        public long OSMID { get; set; }
 
         /// <summary>
         /// The Latitude of this element


### PR DESCRIPTION
Example place with osm_id greater than Int32.MaxValue: https://nominatim.openstreetmap.org/search.php?format=json&street=Lembitu%20pst.%2046&city=Suure-Jaani%20linn&countrycodes=ee

Searching for this place via current Nominatim.API results in Json deserialization exception