### PR TITLE
Fix Error 400 - Invalid Request

### DIFF
--- a/src/Nominatim.API/Geocoders/ReverseGeocoder.cs
+++ b/src/Nominatim.API/Geocoders/ReverseGeocoder.cs
@@ -33,8 +33,8 @@ namespace Nominatim.API.Geocoders {
             c.AddIfSet("format", format);
             c.AddIfSet("key", key);
 
-            c.AddIfSet("lat", r.Latitude);
-            c.AddIfSet("lon", r.Longitude);
+            c.AddIfSet("lat", r.Latitude.Value.ToString(CultureInfo.InvariantCulture.NumberFormat));
+            c.AddIfSet("lon", r.Longitude.Value.ToString(CultureInfo.InvariantCulture.NumberFormat));
             c.AddIfSet("zoom", r.ZoomLevel);
             c.AddIfSet("addressdetails", r.BreakdownAddressElements);
             c.AddIfSet("namedetails", r.ShowAlternativeNames);


### PR DESCRIPTION
Problem: When Lat/Lon were converted from double to string the current local culture setting was used -resulting in xx,xxxxx instead of xx.xxxx