### PR TITLE
Added support for MOCKING HttpClient for UnitTests

### DIFF
--- a/src/Nominatim.API.Tests/AddressLookupMockTests.cs
+++ b/src/Nominatim.API.Tests/AddressLookupMockTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nominatim.API.Address;
+using Nominatim.API.Models;
+
+namespace Nominatim.API.Tests
+{
+    [TestClass]
+    public class AddressLookupMockTests
+    {
+        [TestMethod]
+        public void TestSuccessfulAddressLookup()
+        {
+            const string responseJson = "[{\"place_id\":281979440,\"licence\":\"Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright\",\"osm_type\":\"relation\",\"osm_id\":109166,\"boundingbox\":[\"48.1179069\",\"48.3226679\",\"16.181831\",\"16.5775132\"],\"lat\":\"48.2083537\",\"lon\":\"16.3725042\",\"display_name\":\"Vienna, Austria\",\"class\":\"boundary\",\"type\":\"administrative\",\"importance\":0.769412325825045,\"address\":{\"city\":\"Vienna\",\"country\":\"Austria\",\"country_code\":\"at\"},\"extratags\":{\"ele\":\"542\",\"capital\":\"yes\",\"website\":\"https://www.wien.gv.at/\",\"ref:nuts\":\"AT13;AT130\",\"wikidata\":\"Q1741\",\"ISO3166-2\":\"AT-9\",\"wikipedia\":\"de:Wien\",\"population\":\"1897481\",\"ref:at:gkz\":\"90001\",\"ref:nuts:2\":\"AT13\",\"ref:nuts:3\":\"AT130\",\"description\":\"Wien ist die Hauptstadt der Republik Österreich und zugleich eines der neun österreichischen Bundesländer.\",\"linked_place\":\"city\",\"name:prefix:at\":\"Statutarstadt\",\"population:date\":\"2019-01-01\",\"ISO3166-1:alpha2\":\"AT\",\"capital_ISO3166-1\":\"yes\"},\"namedetails\":{\"name\":\"Wien\"}}]";
+
+            var handlerMock = new MockHttpHandler((req) =>
+                req.RequestUri.ToString() switch
+                {
+                    "https://nominatim.openstreetmap.org/lookup?format=json&addressdetails=1&namedetails=1&extratags=1&osm_ids=R109166" => new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+                    },
+                    _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+                }
+            );
+
+            var x = new AddressSearcher(httpMessageHandler: handlerMock);
+            var r = x.Lookup(new AddressSearchRequest
+            {
+                OSMIDs = new List<string>(new[] { "R109166" }),
+                BreakdownAddressElements = true,
+                ShowAlternativeNames = true,
+                ShowExtraTags = true
+            });
+            r.Wait();
+
+            Assert.AreEqual(1, r.Result.Length);
+            Assert.AreEqual(281979440, r.Result[0].PlaceID);
+        }
+    }
+}

--- a/src/Nominatim.API.Tests/ForwardGeocoderMockTests.cs
+++ b/src/Nominatim.API.Tests/ForwardGeocoderMockTests.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics;
+using System.Text;
+using System.Net;
+using System.Net.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nominatim.API.Geocoders;
+using Nominatim.API.Models;
+
+namespace Nominatim.API.Tests
+{
+    [TestClass]
+    public class ForwardGeocoderMockTests
+    {
+        [TestMethod]
+        public void TestSuccessfulForwardGeocode()
+        {
+            const string responseJson = "[{\"place_id\":321574407,\"licence\":\"Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright\",\"osm_type\":\"way\",\"osm_id\":995417378,\"boundingbox\":[\"38.8637386\",\"38.8637409\",\"-76.9467576\",\"-76.9467515\"],\"lat\":\"38.8637409\",\"lon\":\"-76.9467576\",\"display_name\":\"Pennsylvania Avenue, Washington, District of Columbia, 20746-8001, United States\",\"place_rank\":26,\"category\":\"highway\",\"type\":\"trunk\",\"importance\":0.41000000000000003,\"address\":{\"road\":\"Pennsylvania Avenue\",\"city\":\"Washington\",\"state\":\"District of Columbia\",\"postcode\":\"20746-8001\",\"country\":\"United States\",\"country_code\":\"us\"},\"geojson\":{\"type\":\"LineString\",\"coordinates\":[[-76.9467515,38.8637386],[-76.9467576,38.8637409]]},\"extratags\":{},\"namedetails\":{\"ref\":\"MD 4\",\"name\":\"Pennsylvania Avenue\",\"name:en\":\"Pennsylvania Avenue\"}},{\"place_id\":270072998,\"licence\":\"Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright\",\"osm_type\":\"way\",\"osm_id\":899927559,\"boundingbox\":[\"38.8958906\",\"38.8959158\",\"-77.030956\",\"-77.0308642\"],\"lat\":\"38.8959025\",\"lon\":\"-77.0309076\",\"display_name\":\"Pennsylvania Avenue, Washington, District of Columbia, 20045, United States\",\"place_rank\":27,\"category\":\"highway\",\"type\":\"path\",\"importance\":0.385,\"address\":{\"road\":\"Pennsylvania Avenue\",\"city\":\"Washington\",\"state\":\"District of Columbia\",\"postcode\":\"20045\",\"country\":\"United States\",\"country_code\":\"us\"},\"geojson\":{\"type\":\"LineString\",\"coordinates\":[[-77.0308642,38.8958906],[-77.0309076,38.8959025],[-77.030956,38.8959158]]},\"extratags\":{\"surface\":\"paved\"},\"namedetails\":{\"name\":\"Pennsylvania Avenue\"}}]";
+
+            var handlerMock = new MockHttpHandler((req) =>
+                req.RequestUri.ToString() switch
+                {
+                    "https://nominatim.openstreetmap.org/search?format=jsonv2&q=1600 Pennsylvania Avenue, Washington, DC&addressdetails=1&namedetails=1&polygon_geojson=1&extratags=1" => new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+                    },
+                    _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+                }
+            );
+
+            var x = new ForwardGeocoder(httpMessageHandler: handlerMock);
+
+            var r = x.Geocode(new ForwardGeocodeRequest
+            {
+                queryString = "1600 Pennsylvania Avenue, Washington, DC",
+
+                BreakdownAddressElements = true,
+                ShowExtraTags = true,
+                ShowAlternativeNames = true,
+                ShowGeoJSON = true
+            });
+            r.Wait();
+
+            Assert.AreEqual(2, r.Result.Length);
+            Assert.AreEqual(321574407, r.Result[0].PlaceID);
+        }
+
+        [TestMethod]
+        public void TestSuccessfulReverseGeocodeBuilding()
+        {
+            const string responseJson = "{\"place_id\":159859857,\"licence\":\"Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright\",\"osm_type\":\"way\",\"osm_id\":238241022,\"lat\":\"38.897699700000004\",\"lon\":\"-77.03655315\",\"place_rank\":30,\"category\":\"office\",\"type\":\"government\",\"importance\":0.6347211541681101,\"addresstype\":\"office\",\"name\":\"White House\",\"display_name\":\"White House, 1600, Pennsylvania Avenue Northwest, Washington, District of Columbia, 20500, United States\",\"address\":{\"office\":\"White House\",\"house_number\":\"1600\",\"road\":\"Pennsylvania Avenue Northwest\",\"city\":\"Washington\",\"state\":\"District of Columbia\",\"postcode\":\"20500\",\"country\":\"United States\",\"country_code\":\"us\"},\"extratags\":{\"image\":\"http://upload.wikimedia.org/wikipedia/commons/a/af/WhiteHouseSouthFacade.JPG\",\"level\":\"-1-3\",\"website\":\"https://www.whitehouse.gov/\",\"wikidata\":\"Q35525\",\"architect\":\"James Hoban\",\"dcgis:aid\":\"293211\",\"dcgis:gis\":\"HSE_0001\",\"dcgis:ssl\":\"0187S 0800\",\"dcgis:url\":\"http://www.planning.dc.gov/planning/cwp/view,a,1284,q,570748,planningNav_GID,1706,planningNav,%7C33515%7C.asp\",\"wikipedia\":\"en:White House\",\"dcgis:area\":\"5170.992039\",\"government\":\"presidency\",\"start_date\":\"1800-11-01\",\"wheelchair\":\"yes\",\"dcgis:label\":\"The White House\",\"dcgis:length\":\"635.024279062\",\"dcgis:address\":\"1600 Pennsylvania Ave, NW\",\"dcgis:objectid\":\"569\",\"dcgis:list_info\":\"Reg\",\"dcgis:nr_eligibl\":\"0\",\"dcgis:update_date\":\"Wed Feb 01 00:00:00 UTC 2006\"},\"namedetails\":{\"name\":\"White House\",\"name:br\":\"Ti Gwenn\",\"name:cs\":\"Bílý dům\",\"name:de\":\"Weißes Haus\",\"name:en\":\"White House\",\"name:fa\":\"کاخ سفید\",\"name:fi\":\"Valkoinen talo\",\"name:fr\":\"Maison Blanche\",\"name:hi\":\"व्हाइट हाउस\",\"name:hr\":\"Bijela kuća\",\"name:hu\":\"Fehér Ház\",\"name:it\":\"Casa Bianca\",\"name:ja\":\"ホワイトハウス\",\"name:ko\":\"백악관\",\"name:ku\":\"Qesra Spî\",\"name:lt\":\"Baltieji Rūmai\",\"name:nl\":\"Witte Huis\",\"name:pt\":\"Casa Branca\",\"name:ro\":\"Casa Albă\",\"name:ru\":\"Белый дом\",\"name:sk\":\"Biely dom\",\"name:sv\":\"Vita huset\",\"name:tr\":\"Beyaz Saray\",\"name:uk\":\"Білий дім\",\"name:zh\":\"白宫\",\"alt_name:hr\":\"Bila kuća\",\"addr:housename\":\"The White House\"},\"boundingbox\":[\"38.8974908\",\"38.897911\",\"-77.0368537\",\"-77.0362519\"],\"geojson\":{\"type\":\"Polygon\",\"coordinates\":[[[-77.0368537,38.8975574],[-77.0367914,38.8975573],[-77.0367838,38.8975573],[-77.0367445,38.8975573],[-77.0367006,38.8975572],[-77.0366639,38.8975572],[-77.0366562,38.8975401],[-77.0366445,38.8975253],[-77.036636,38.8975176],[-77.0366217,38.8975078],[-77.0366061,38.8975003],[-77.0365845,38.8974938],[-77.0365616,38.8974908],[-77.0365503,38.8974911],[-77.0365387,38.8974914],[-77.0365194,38.897495],[-77.0364977,38.8975026],[-77.0364832,38.8975103],[-77.0364701,38.8975201],[-77.036461,38.8975292],[-77.0364517,38.8975421],[-77.0364451,38.897557],[-77.0363987,38.8975569],[-77.036321,38.8975569],[-77.0363105,38.8975569],[-77.036252,38.897557],[-77.0362519,38.897598],[-77.0362528,38.897621],[-77.0362528,38.8976491],[-77.0362528,38.8976492],[-77.0362528,38.8976776],[-77.0362528,38.8976962],[-77.0362528,38.8977032],[-77.0362528,38.8977034],[-77.0362527,38.8977387],[-77.0362527,38.8977562],[-77.0362527,38.8977606],[-77.0362526,38.8977951],[-77.0363111,38.8977952],[-77.0363412,38.8977952],[-77.0363982,38.8977952],[-77.0363984,38.8977953],[-77.0364305,38.8977953],[-77.036455,38.8977953],[-77.0364549,38.8978187],[-77.0364548,38.8978339],[-77.0364548,38.8978441],[-77.0364548,38.8978548],[-77.0364547,38.897883],[-77.0364547,38.8978949],[-77.0364547,38.8979108],[-77.0365326,38.8979109],[-77.0365602,38.8979109],[-77.036643,38.897911],[-77.036643,38.8978966],[-77.036643,38.897885],[-77.0366428,38.8978553],[-77.0366428,38.8978448],[-77.0366427,38.8978343],[-77.0366429,38.8978268],[-77.0366432,38.8978169],[-77.0366432,38.8977955],[-77.0366679,38.8977955],[-77.036703,38.8977956],[-77.0367461,38.8977956],[-77.0367946,38.8977956],[-77.0368114,38.8977958],[-77.0368535,38.8977959],[-77.0368537,38.8977338],[-77.0368535,38.8977184],[-77.0368535,38.8977036],[-77.0368535,38.8976869],[-77.0368535,38.8976765],[-77.0368535,38.8976497],[-77.0368536,38.8976282],[-77.0368536,38.8975961],[-77.0368537,38.8975574]]]}}";
+
+            var handlerMock = new MockHttpHandler((req) =>
+                req.RequestUri.ToString() switch
+                {
+                    "https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=38.8976763&lon=-77.0365298&addressdetails=1&namedetails=1&polygon_geojson=1&extratags=1" => new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+                    },
+                    _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+                }
+            );
+
+            var y = new ReverseGeocoder(httpMessageHandler: handlerMock);
+
+            var r2 = y.ReverseGeocode(new ReverseGeocodeRequest
+            {
+                Longitude = -77.0365298,
+                Latitude = 38.8976763,
+
+                BreakdownAddressElements = true,
+                ShowExtraTags = true,
+                ShowAlternativeNames = true,
+                ShowGeoJSON = true
+            });
+            r2.Wait();
+
+            Assert.AreEqual(159859857, r2.Result.PlaceID);
+        }
+
+
+        [TestMethod]
+        public void TestSuccessfulReverseGeocodeRoad()
+        {
+            var z = new ReverseGeocoder();
+
+            var r3 = z.ReverseGeocode(new ReverseGeocodeRequest
+            {
+                Longitude = -58.7051622809683,
+                Latitude = -34.440723129053,
+
+                BreakdownAddressElements = true,
+                ShowExtraTags = true,
+                ShowAlternativeNames = true,
+                ShowGeoJSON = true
+            });
+            r3.Wait();
+
+            Assert.IsTrue((r3.Result.PlaceID > 0) && (r3.Result.Category == "highway") && (r3.Result.ClassType == "milestone"));
+        }
+    }
+}

--- a/src/Nominatim.API.Tests/ForwardGeocoderTests.cs
+++ b/src/Nominatim.API.Tests/ForwardGeocoderTests.cs
@@ -4,7 +4,7 @@ using Nominatim.API.Models;
 
 namespace Nominatim.API.Tests {
     [TestClass]
-    public class GeocoderTests {
+    public class ForwardGeocoderTests {
         [TestMethod]
         public void TestSuccessfulForwardGeocode() {
             var x = new ForwardGeocoder();

--- a/src/Nominatim.API.Tests/MockHttpHandler.cs
+++ b/src/Nominatim.API.Tests/MockHttpHandler.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nominatim.API.Tests
+{
+    internal class MockHttpHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> mockConfig;
+
+        public MockHttpHandler(Func<HttpRequestMessage, HttpResponseMessage> mockConfig)
+        {
+            this.mockConfig = mockConfig;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {            
+            return Task.FromResult(mockConfig(request));
+        }
+    }
+}

--- a/src/Nominatim.API/Address/AddressSearcher.cs
+++ b/src/Nominatim.API/Address/AddressSearcher.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Nominatim.API.Extensions;
 using Nominatim.API.Models;
@@ -12,6 +13,8 @@ namespace Nominatim.API.Address {
         public string url;
         //jsonv2 not supported for lookup
         private readonly string format = "json";
+        private readonly WebInterface _webInterface;
+
         /// <summary>
         /// API Key, if you are using an Nominatim service that requires one.
         /// </summary>
@@ -21,8 +24,9 @@ namespace Nominatim.API.Address {
         /// Constructur
         /// </summary>
         /// <param name="URL">URL to Nominatim service.  Defaults to OSM demo site.</param>
-        public AddressSearcher(string URL = null) {
-            url = URL ?? @"https://nominatim.openstreetmap.org/lookup";
+        public AddressSearcher(string URL = "https://nominatim.openstreetmap.org/lookup", HttpMessageHandler httpMessageHandler=null, bool disposeMessageHandler=false) {
+            url = URL;
+            _webInterface = new WebInterface(httpMessageHandler, disposeMessageHandler);   
         }
 
         /// <summary>
@@ -31,7 +35,7 @@ namespace Nominatim.API.Address {
         /// <param name="req">Search request object</param>
         /// <returns>Array of lookup reponses</returns>
         public async Task<AddressLookupResponse[]> Lookup(AddressSearchRequest req) {
-            var result = await WebInterface.GetRequest<AddressLookupResponse[]>(url, buildQueryString(req)).ConfigureAwait(false);
+            var result = await _webInterface.GetRequest<AddressLookupResponse[]>(url, buildQueryString(req)).ConfigureAwait(false);
             return result;
         }
 

--- a/src/Nominatim.API/Geocoders/ForwardGeocoder.cs
+++ b/src/Nominatim.API/Geocoders/ForwardGeocoder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Nominatim.API.Extensions;
 using Nominatim.API.Models;
@@ -13,7 +14,7 @@ namespace Nominatim.API.Geocoders {
         ///     Constructor
         /// </summary>
         /// <param name="URL">URL to Nominatim service.  Defaults to OSM demo site.</param>
-        public ForwardGeocoder(string URL = null) : base(URL ?? @"https://nominatim.openstreetmap.org/search") {
+        public ForwardGeocoder(string URL = null, HttpMessageHandler httpMessageHandler = null, bool disposeMessageHandler = false) : base(URL ?? @"https://nominatim.openstreetmap.org/search", httpMessageHandler, disposeMessageHandler) {
         }
 
         /// <summary>
@@ -22,7 +23,7 @@ namespace Nominatim.API.Geocoders {
         /// <param name="req">Geocode request object</param>
         /// <returns>Array of geocode responses</returns>
         public async Task<GeocodeResponse[]> Geocode(ForwardGeocodeRequest req) {
-            var result = await WebInterface.GetRequest<GeocodeResponse[]>(url, buildQueryString(req)).ConfigureAwait(false);
+            var result = await base.webInterface.GetRequest<GeocodeResponse[]>(url, buildQueryString(req)).ConfigureAwait(false);
             return result;
         }
 

--- a/src/Nominatim.API/Geocoders/GeocoderBase.cs
+++ b/src/Nominatim.API/Geocoders/GeocoderBase.cs
@@ -1,8 +1,14 @@
-﻿namespace Nominatim.API.Geocoders {
+﻿using System.Net.Http;
+using Nominatim.API.Web;
+
+namespace Nominatim.API.Geocoders {
     public abstract class GeocoderBase {
-        protected GeocoderBase(string URL) {
+        protected GeocoderBase(string URL, HttpMessageHandler handler = null, bool disposeMessageHandler = false) {
             url = URL;
+
+            webInterface = new WebInterface(handler, disposeMessageHandler);
         }
+        protected readonly WebInterface webInterface;
 
         /// <summary>
         /// URL to Nominatim service

--- a/src/Nominatim.API/Geocoders/ReverseGeocoder.cs
+++ b/src/Nominatim.API/Geocoders/ReverseGeocoder.cs
@@ -1,6 +1,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Nominatim.API.Extensions;
 using Nominatim.API.Models;
@@ -15,7 +16,7 @@ namespace Nominatim.API.Geocoders {
         ///     Constructor
         /// </summary>
         /// <param name="URL">URL to Nominatim service.  Defaults to OSM demo site.</param>
-        public ReverseGeocoder(string URL = null) : base(URL ?? @"https://nominatim.openstreetmap.org/reverse") {
+        public ReverseGeocoder(string URL = null, HttpMessageHandler httpMessageHandler = null, bool disposeMessageHandler = false) : base(URL ?? @"https://nominatim.openstreetmap.org/reverse", httpMessageHandler, disposeMessageHandler) {
         }
 
         /// <summary>
@@ -24,7 +25,7 @@ namespace Nominatim.API.Geocoders {
         /// <param name="req">Reverse geocode request object</param>
         /// <returns>A single reverse geocode response</returns>
         public async Task<GeocodeResponse> ReverseGeocode(ReverseGeocodeRequest req) {
-            var result = await WebInterface.GetRequest<GeocodeResponse>(url, buildQueryString(req)).ConfigureAwait(false);
+            var result = await base.webInterface.GetRequest<GeocodeResponse>(url, buildQueryString(req)).ConfigureAwait(false);
             return result;
         }
 

--- a/src/Nominatim.API/Nominatim.API.csproj
+++ b/src/Nominatim.API/Nominatim.API.csproj
@@ -11,9 +11,9 @@
     <PackageTags>nominatim, osm, geocode, geocoding</PackageTags>
     <Version>1.6.1</Version>
     <PackageLicenseUrl>https://github.com/f1ana/Nominatim.API/blob/master/LICENSE</PackageLicenseUrl>
-    <AssemblyVersion>1.6.1.0</AssemblyVersion>
-    <FileVersion>1.6.1.0</FileVersion>
-    <PackageVersion>1.6.1</PackageVersion>
+    <AssemblyVersion>1.7.0.0</AssemblyVersion>
+    <FileVersion>1.7.0.0</FileVersion>
+    <PackageVersion>1.7.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Nominatim.API/Web/WebInterface.cs
+++ b/src/Nominatim.API/Web/WebInterface.cs
@@ -12,10 +12,15 @@ namespace Nominatim.API.Web {
     /// <summary>
     ///     Provides a means of sending HTTP requests to a Nominatim server
     /// </summary>
-    public static class WebInterface {
-        private static readonly HttpClient _httpClient = new HttpClient();
+    public class WebInterface {
+        private readonly HttpClient _httpClient;
 
-        static WebInterface() {
+        public WebInterface(HttpMessageHandler httpMessageHandler=null, bool disposeMessageHandler=false) {
+            if (httpMessageHandler != null)
+                _httpClient = new HttpClient(httpMessageHandler, disposeMessageHandler);
+            else
+                _httpClient = new HttpClient();
+
             _httpClient.DefaultRequestHeaders.UserAgent.Clear();
             _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("f1ana.Nominatim.API", Assembly.GetExecutingAssembly().GetName().Version.ToString()));
         }
@@ -27,7 +32,7 @@ namespace Nominatim.API.Web {
         /// <param name="url">URL of Nominatim server method</param>
         /// <param name="parameters">Query string parameters</param>
         /// <returns>Deserialized instance of T</returns>
-        public static async Task<T> GetRequest<T>(string url, Dictionary<string, string> parameters) {
+        public async Task<T> GetRequest<T>(string url, Dictionary<string, string> parameters) {
             var req = addQueryStringToUrl(url, parameters);
 
             var result = await _httpClient.GetStringAsync(req).ConfigureAwait(false);


### PR DESCRIPTION
The overall goal was, to allow UNIT TESTING of the `ForwardGeocoder`, `ReverseGeocoder`, `AdressSearcher`.
To do that, mocking of `HttpClient` traffic is required, so that you're not actually testing against a real NOMINATIM service, but rather against pre-recorded responses.

Here's the changes I've made..
* Turned `WebInterface` from a static singleton to an instantiated variable in `GeocoderBase` / `AddressSearcher`
* Turned `HttpClient` from a static singleton to an instantiated variable in `WebInterface`

* Added new *constructor parameters* so that a custom `HttpMessageHandler` can be passed in - all the way through to `HttpClient` (through `ForwardGeocoder`, `ReverseGeocoder` --> `GeocoderBase` --> `WebInterface` --> `HttpClient`)

* Added a sample of a mocked `HttpMessageHandler` class, that responds to HTTP requests with a hardcoded fake/mock response

* Added new UnitTests that use the mocked `HttpMessageHandler` and therefore are predictable to test.

Let me know if any changes are required!