### PR TITLE
feat: add missing fields in AddressResult and BaseNominatimResponse

### DIFF
--- a/src/Nominatim.API/Models/AddressResult.cs
+++ b/src/Nominatim.API/Models/AddressResult.cs
@@ -100,5 +100,23 @@ namespace Nominatim.API.Models {
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <summary>
+        ///     Tourism
+        /// </summary>
+        [JsonProperty("tourism")]
+        public string Tourism { get; set; }
+
+        /// <summary>
+        ///     Municipality
+        /// </summary>
+        [JsonProperty("municipality")]
+        public string Municipality { get; set; }
+
+        /// <summary>
+        ///     Quarter
+        /// </summary>
+        [JsonProperty("quarter")]
+        public string Quarter { get; set; }
     }
 }

--- a/src/Nominatim.API/Models/BaseNominatimResponse.cs
+++ b/src/Nominatim.API/Models/BaseNominatimResponse.cs
@@ -111,6 +111,10 @@ namespace Nominatim.API.Models {
         [JsonProperty("place_rank")]
         public string PlaceRank { get; set; }
 
-
+        /// <summary>
+        /// The name of this element.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
     }
 }


### PR DESCRIPTION
Hi,

I've made an update which adds a few missing fields to mappers.

`AddressResult`

- Tourism
- Municipality (i need that that field in personel use)
- Quarter

`BaseNominatimResponse`
- Name

These changes closes #29 .