### PR TITLE
fix: neighbourhood typo

### DIFF
--- a/src/Nominatim.API/Models/AddressResult.cs
+++ b/src/Nominatim.API/Models/AddressResult.cs
@@ -54,9 +54,9 @@ namespace Nominatim.API.Models {
         public string Pedestrian { get; set; }
 
         /// <summary>
-        ///     Neighborhood
+        ///     Neighbourhood
         /// </summary>
-        [JsonProperty("neighborhood")]
+        [JsonProperty("neighbourhood")]
         public string Neighborhood { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Little typo fix for mapping neighbourhood in the `AddressResult `,

I've kept original property name (`Neighborhood`) for compatibility.

Fixes #30.