### PR TITLE
Added fluent api for microsoft-esque dependency registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 **What does this do?**
 
-This library can be used for utilizing geocoding (forward and reverse), in addition to address lookups, with the Nominatim HTTP API. Targets .NET 8 and .NET Standard 2.0. 
+This library can be used for utilizing geocoding (forward and reverse), in addition to address lookups, with the Nominatim HTTP API. Targets .NET 8 and .NET Standard 2.0.
 \
 \
 \
 **Why would I use this?**
 
-This provides a simple method for common tasks within the [Nominatim](https://nominatim.org/) service.  While Nominatim's API is simple to use, setting up the correct query parameters for a given action can be redundant and error-prone.  My goal is to have a library with a set of services with which you can pass strongly-typed requests to, and receive strongly-typed responses.
+This provides a simple method for common tasks within the [Nominatim](https://nominatim.org/) service. While Nominatim's API is simple to use, setting up the correct query parameters for a given action can be redundant and error-prone. My goal is to have a library with a set of services with which you can pass strongly-typed requests to, and receive strongly-typed responses.
 \
 \
 \
@@ -16,11 +16,27 @@ This provides a simple method for common tasks within the [Nominatim](https://no
 
 _Major changes in usage with the release of 2.0.0, read carefully!_
 
-Nominatim.API now targets .NET Standard 2.0 and .NET 8, which should mean that we can target a wide range of .NET applications, theoretically even down to 4.6.2.  We plan to support .NET Standard 2.0 and the latest .NET LTS.
+Nominatim.API now targets .NET Standard 2.0 and .NET 8, which should mean that we can target a wide range of .NET applications, theoretically even down to 4.6.2. We plan to support .NET Standard 2.0 and the latest .NET LTS.
 
-With Nominatim.API 2.0.0, it is more straightforward to support codebases that rely on dependency injection.  Furthermore, we are now using modern methods to facilitate web requests, such as `HttpClientFactory` and `HttpClient`.  This library does not register any interfaces and implementations, and expects you to do so in a manner that you find to be appropriate.  This is also done to allow the developer to register and customize how the `HttpClient` is used to their liking.
+With Nominatim.API 2.0.0, it is more straightforward to support codebases that rely on dependency injection. Furthermore, we are now using modern methods to facilitate web requests, such as `HttpClientFactory` and `HttpClient`. This library does not register any interfaces and implementations automatically, and expects you to do so in a manner that you find to be appropriate. This is also done to allow the developer to register and customize how the `HttpClient` is used to their liking.
 
-Here are the interfaces and implementations that should be registered:
+To register the Nominatim.API services in your dependencies, use the `AddNominatim` extension method.
+Register your desired services via the `Add...` methods, e.g.
+
+```csharp
+builder.Services.AddNominatim()
+    .WithAddressSearch()
+    .WithForwardGeocoder()
+    .WitReverseGeocoder();
+```
+
+or, as a shortcut for all services
+
+```csharp
+builder.Services.AddNominatim().WithAllGeocoders();
+```
+
+If you don't use Microsoft DI, you can register the services manually:
 
 `INominatimWebInterface` -> `NominatimWebInterface`
 
@@ -30,7 +46,7 @@ Here are the interfaces and implementations that should be registered:
 
 `IForwardGeocoder` -> `ForwardGeocoder`
 
-Finally, be sure to call `.AddHttpClient()` to your `ServiceCollection` for a vanilla `HttpClient` implementation.  Customize as needed for your respective DI library or use case.
+Finally, be sure to call `.AddHttpClient()` to your `ServiceCollection` for a vanilla `HttpClient` implementation. Customize as needed for your respective DI library or use case.
 
 Code surface is very simple, here are the methods exposed by interfaces:
 
@@ -52,4 +68,4 @@ Code surface is very simple, here are the methods exposed by interfaces:
 \
 **Contributions**
 
-I welcome any and all suggestions or improvements to the codebase.  Thanks for dropping by and hope you find a good use for this library!
+I welcome any and all suggestions or improvements to the codebase. Thanks for dropping by and hope you find a good use for this library!

--- a/src/Nominatim.API/Configuration/NominatimConfiguration.cs
+++ b/src/Nominatim.API/Configuration/NominatimConfiguration.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Nominatim.API.Address;
+using Nominatim.API.Geocoders;
+using Nominatim.API.Interfaces;
+
+namespace Nominatim.API.Configuration
+{
+    /// <inheritdoc/>
+    internal class NominatimConfiguration : INominatimConfiguration
+    {
+        private readonly IServiceCollection serviceCollection;
+
+        public NominatimConfiguration(IServiceCollection serviceCollection)
+        {
+            this.serviceCollection = serviceCollection;
+        }
+
+        /// <inheritdoc/>
+        public INominatimConfiguration WithAddressSearch()
+        {
+            serviceCollection.TryAddTransient<IAddressSearcher, AddressSearcher>();
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public INominatimConfiguration WithForwardGeocoder()
+        {
+            serviceCollection.TryAddTransient<IForwardGeocoder, ForwardGeocoder>();
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public INominatimConfiguration WithReverseGeocoder()
+        {
+            serviceCollection.TryAddTransient<IReverseGeocoder, ReverseGeocoder>();
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public INominatimConfiguration WithAllGeocoders()
+        {
+            return this.WithAddressSearch().WithForwardGeocoder().WithReverseGeocoder();
+        }
+    }
+}

--- a/src/Nominatim.API/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Nominatim.API/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Nominatim.API.Configuration;
+using Nominatim.API.Interfaces;
+using Nominatim.API.Web;
+
+namespace Nominatim.API.Extensions
+{
+    /// <summary>
+    /// Extensions for dependency injection
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Add the base Nominatim service
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> from your DI</param>
+        /// <returns>A <see cref="INominatimConfiguration"/> instance to register your desired services</returns>
+        public static INominatimConfiguration AddNominatim(this IServiceCollection services)
+        {
+            services.TryAddTransient<INominatimWebInterface, NominatimWebInterface>();
+            return new NominatimConfiguration(services);
+        }
+    }
+}

--- a/src/Nominatim.API/Interfaces/INominatimConfiguration.cs
+++ b/src/Nominatim.API/Interfaces/INominatimConfiguration.cs
@@ -1,0 +1,34 @@
+﻿namespace Nominatim.API.Interfaces
+{
+    /// <summary>
+    /// Configure the Nominatim DI registration
+    /// </summary>
+    public interface INominatimConfiguration
+    {
+        /// <summary>
+        /// Add the <see cref="IAddressSearcher"/> to your services
+        /// </summary>
+        /// <returns>The same <see cref="INominatimConfiguration"/> instance to chain your configuration</returns>
+        INominatimConfiguration WithAddressSearch();
+
+        /// <summary>
+        /// Add the <see cref="IReverseGeocoder"/> to your services
+        /// </summary>
+        /// <returns>The same <see cref="INominatimConfiguration"/> instance to chain your configuration</returns>
+        INominatimConfiguration WithReverseGeocoder();
+
+        /// <summary>
+        /// Add the <see cref="IForwardGeocoder"/> to your services
+        /// </summary>
+        /// <returns>The same <see cref="INominatimConfiguration"/> instance to chain your configuration</returns>
+        INominatimConfiguration WithForwardGeocoder();
+
+        /// <summary>
+        /// A shortcut to add all geocoders
+        /// </summary>
+        /// <returns>The same <see cref="INominatimConfiguration"/> instance to chain your configuration</returns>
+        INominatimConfiguration WithAllGeocoders();
+
+
+    }
+}


### PR DESCRIPTION
Hi, I added a small fluent API for the default Microsoft DI container. This should be familiar to any C# developer using the default DI container.

It is 100% backwards compatible, so manual registration still works - this is reflected in the README.